### PR TITLE
Allow returning games from Find a Checkout

### DIFF
--- a/app/assets/javascripts/checkouts.js
+++ b/app/assets/javascripts/checkouts.js
@@ -124,6 +124,18 @@ $(document).ready(function(){
         });
     });
 
+    $('#found-div').delegate('.return-game', 'click', function(){
+        var _me = $(this);
+        $.post('/return', { co_id: _me.data('checkout-id') }).success(function(response){
+            $.notify('Returned game successfully!');
+            var cell = _me.closest('.col-xs-2');
+            cell.html(response.time);
+            cell.next().html("RETURNED");
+        }).error(function(){
+            $.notify(DEFAULT_ERROR, 'danger');
+        });
+    });
+
     $('#find-barcode').change(function(){
         $.get('/find', $(this).serialize(), null, 'script');
     });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -223,7 +223,7 @@ path[data-event="geek-girl-con"] {
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-    background-color: #eeeeee;
+    background-color: #eeeeee !important;
 }
 
 .alert-text-box {

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -27,9 +27,14 @@ class CheckoutsController < ApplicationController
   end
 
   def return
-    Checkout.find(params[:co_id]).return
+    checkout = Checkout.find(params[:co_id])
+    checkout.return
 
-    render json: :nothing
+    render json: { time: ct(checkout.return_time).strftime('%m/%d %I:%M%P') }
+  end
+
+  def ct(datetime)
+    datetime - @offset.hours
   end
 
   def find

--- a/app/views/checkouts/_checkout_row.html.erb
+++ b/app/views/checkouts/_checkout_row.html.erb
@@ -3,7 +3,11 @@
         <%= ct(checkout.check_out_time).strftime('%m/%d %I:%M%P') %>
     </td>
     <td class="col-xs-2">
-        <%= checkout.return_time ? ct(checkout.return_time).strftime('%m/%d %I:%M%P') : nil %>
+        <% if checkout.return_time %>
+            <%= ct(checkout.return_time).strftime('%m/%d %I:%M%P') %>
+        <% else %>
+            <input type="button" data-checkout-id="<%= checkout.id %>" class="btn btn-danger return-game" value="Return Game" />
+        <% end %>
     </td>
     <td class="col-xs-2">
         <%= checkout.closed ? 'RETURNED' : 'CHECKED OUT' %>


### PR DESCRIPTION
If an attendee brings a game back without their badge, or wants to
return a game for another attendee, we would have to scan the game, copy
the attendee's barcode, then navigate to the Checkout & Return page to
paste the barcode and return the game.

This change adds a Return button to the Find a Checkout page if the game
is currently checked out.