### PR TITLE
Docker development support & no event fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.1.4
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /library_mk5
+WORKDIR /library_mk5
+COPY Gemfile /library_mk5/Gemfile
+COPY Gemfile.lock /library_mk5/Gemfile.lock
+ENV RAILS_ENV docker
+RUN bundle install
+COPY . /library_mk5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,3 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   will_paginate
-
-BUNDLED WITH
-   1.10.5

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -1,7 +1,7 @@
 class CheckoutsController < ApplicationController
 
   def index
-    if Event.current.setup_complete?
+    if Event.current.try(:setup_complete?)
       @checkouts = Checkout.all
     else
       @current_event = Event.current

--- a/app/views/events/_setup.html.erb
+++ b/app/views/events/_setup.html.erb
@@ -1,7 +1,8 @@
+<% if @current_event %>
 <div class="row setup-msg text-center">
     <div class="col-xs-1"></div>
     <div class="col-xs-10">
-        <h3>Welcome to setup for <%= Event.current.formatted_name %>!</h3>
+        <h3>Welcome to setup for <%= @current_event.formatted_name %>!</h3>
         <p>Please complete these steps to set up the Tabletop Library. Check off each item once it's complete.</p>
     </div>
 </div>
@@ -137,3 +138,11 @@
         });
     });
 </script>
+<% else %>
+<div class="row no-event-msg">
+    <div class="col-xs-1"></div>
+    <div class="col-xs-10" style="text-align: center;">
+        <h4>No event created! Please go <%= link_to("create one", :events) %>.</h4>
+    </div>
+</div>
+<% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,14 +10,14 @@
     <a href="/ReadMe.html" target="_blank" class="btn btn-default">Read the docs >></a>
 </div>
 
-<footer class="tt-footer" data-event="<%= @current_event.short_name %>">
+<footer class="tt-footer" data-event="<%= @current_event.try(:short_name) %>">
     <div class="col-md-3">
         <a href="/longest">
             Today's longest checkout: <span id="longest-open-checkout">00:03:05</span>
         </a>
     </div>
     <div class="col-md-6" style="text-align: center;">
-        Welcome to <%= @current_event.formatted_name %>!
+        Welcome to <%= @current_event.try(:formatted_name) %>!
     </div>
     <div class="col-md-3" style="text-align: right;">
         <a href="/recent">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,7 @@
-<header data-event="<%= @current_event.short_name %>" style="height: 90px;">
+<header data-event="<%= @current_event.try(:short_name) %>" style="height: 90px;">
     <div class="col-xs-1"></div>
     <div class="col-xs-10">
+      <% if @current_event %>
         <% if @current_event.is_pax %>
             <div id="tabletop-tag" class="pax-tag"></div>
             <div id="logo">
@@ -20,6 +21,7 @@
         <% elsif @current_event.is_shux %>
             <div id="tabletop-tag" class="shux-tag" style="height: 90px;"></div>
         <% end %>
+      <% end %>
     </div>
     <div class="col-xs-1"></div>
 </header>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,4 +1,4 @@
-<% if @current_event.is_last_day? %>
+<% if @current_event.try(:is_last_day?) %>
     <div class="row">
         <div class="col-md-1"></div>
         <div class="col-md-10 alert alert-info" style="text-align: center; margin: 5px 0;">

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: postgresql
-# encoding set for win environments
+  # encoding set for win environments
   encoding: win1252
   pool: 5
   timeout: 5000
@@ -10,6 +10,12 @@ default: &default
 development:
   <<: *default
   database: library_mk4_dev
+
+docker:
+  <<: *default
+  database: library_mk4_docker
+  host: db
+  encoding: utf8
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/environments/docker.rb
+++ b/config/environments/docker.rb
@@ -1,0 +1,41 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+  # TODO: Evaluate using prod env over enabling these
+  # config.cache_classes = true
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
+  # Raise an error on page load if there are pending migrations.
+  config.active_record.migration_error = :page_load
+
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = true
+  # TODO: Evaluate using prod env over enabling these
+  # config.assets.debug = false
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,6 +10,9 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+docker:
+  secret_key_base: 2ccc80f736875b54b59e5e57f37ba774df4399227f7a2b9a268332c2859977b276fafd613358ffebeecab1c1fe44f4fb5243753308aafa040b4e8250bae5cada
+
 development:
   secret_key_base: cbac2a461d1dd504876c34a879120f485c526762e341ab09840289fa5372c2ae70d87adde98eb263bd78909bf6457a4f457cbf77b7df71741228bcca7ab485d9
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/library_mk5
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
When you have no event, display a message that points you towards event creation page instead of throwing an error.

Also added support for docker development using docker compose - makes development environment setup much quicker/easier. Nothing should be broken for anyone who doesn't want to use it.